### PR TITLE
Set relevant responses with Cache-Control: no-store

### DIFF
--- a/apitess/multitexts.py
+++ b/apitess/multitexts.py
@@ -112,8 +112,12 @@ def retrieve_status(results_id):
         response.status_code = 404
         return response
     status = results_status_found[0]
-    return flask.jsonify(results_id=status.results_id, status=status.status,
-            message=status.msg)
+    response = flask.jsonify(
+        results_id=status.results_id, status=status.status, message=status.msg)
+    if status.status != tesserae.db.entities.Search.DONE and \
+            status.status != tesserae.db.entities.Search.FAILED:
+        response.headers['Cache-Control'] = 'no-store'
+    return response
 
 
 @bp.route('/<results_id>/')

--- a/apitess/parallels.py
+++ b/apitess/parallels.py
@@ -158,8 +158,12 @@ def retrieve_status(results_id):
         response.status_code = 404
         return response
     status = results_status_found[0]
-    return flask.jsonify(results_id=status.results_id, status=status.status,
-            message=status.msg)
+    response = flask.jsonify(
+        results_id=status.results_id, status=status.status, message=status.msg)
+    if status.status != tesserae.db.entities.Search.DONE and \
+            status.status != tesserae.db.entities.Search.FAILED:
+        response.headers['Cache-Control'] = 'no-store'
+    return response
 
 
 @bp.route('/<results_id>/')


### PR DESCRIPTION
Ideally, browsers will not cache result statuses and results that are not found because they are not yet ready.  Hopefully, adding these headers will force the browser to check with the server for new result statuses and completed result information.