### PR TITLE
Ingestion via the API

### DIFF
--- a/apitess/errors.py
+++ b/apitess/errors.py
@@ -1,4 +1,5 @@
 """A place for error message code"""
+from bson.objectid import ObjectId
 import flask
 
 
@@ -13,6 +14,20 @@ def bad_object_id(object_id):
         400,
         object_id=object_id,
         message='Provided identifier ({}) is malformed.'.format(object_id))
+
+
+def check_object_id(object_id):
+    """Checks whether the string could be a well-formed ObjectId
+
+    If the string could not be made into an ObjectId, an error message will be
+    returned by this function.
+
+    If the string coult be made into an ObjectId, None is returned by this
+    function.
+    """
+    if not ObjectId.is_valid(object_id):
+        return bad_object_id(object_id)
+    return None
 
 
 def bad_object_ids(object_ids, args):
@@ -49,4 +64,25 @@ def check_requireds(received, requireds):
             data=received,
             message=('The request data payload is missing the following '
                      'required key(s): {}'.format(', '.join(missing))))
+    return None
+
+
+def check_prohibited(received, prohibited):
+    """Checks whether prohibited keys are found in received dictionary
+
+    If any prohibited keys are present, they will be collected into an error
+    message, and this error message will be returned by this function
+
+    If no prohibited keys are found, None is returned by this function
+    """
+    found = []
+    for key in prohibited:
+        if key in received:
+            found.append(key)
+    if found:
+        return error(
+            400,
+            data=received,
+            message=('The request data payload contains the following '
+                     'prohibited key(s): {}'.format(', '.join(found))))
     return None

--- a/apitess/multitexts.py
+++ b/apitess/multitexts.py
@@ -13,6 +13,7 @@ import tesserae.utils.multitext
 
 bp = flask.Blueprint('multitexts', __name__, url_prefix='/multitexts')
 
+
 @bp.route('/', methods=('POST', 'OPTIONS',))
 @cross_origin(expose_headers='Location')
 def submit_multitext():
@@ -58,7 +59,8 @@ def submit_multitext():
         return apitess.errors.error(
             400,
             data=received,
-            message='Specified unit_type ({}) is not acceptable; acceptable values: {}'.format(received['unit_type'], accepted_unit_types)
+            message=(f'Specified unit_type ({received["unit_type"]}) is not '
+                     f'acceptable; acceptable values: {accepted_unit_types}')
         )
 
     results_id = tesserae.utils.multitext.check_cache(
@@ -94,7 +96,7 @@ def submit_multitext():
             500,
             data=received,
             message=('The search request could not be added to the queue. '
-                'Please try again in a few minutes')
+                     'Please try again in a few minutes')
         )
     return response
 

--- a/apitess/parallels.py
+++ b/apitess/parallels.py
@@ -131,7 +131,7 @@ def submit_search():
 
     try:
         tesserae.utils.search.submit_search(
-            flask.g.jobqueue, results_id, method['name'], {
+            flask.g.jobqueue, flask.g.db, results_id, method['name'], {
                 'source': TextOptions(source_text, source['units']),
                 'target': TextOptions(target_text, target['units']),
                 'feature': method['feature'],

--- a/mkdocs-site/docs/endpoints/texts.md
+++ b/mkdocs-site/docs/endpoints/texts.md
@@ -117,18 +117,26 @@ Appropriate JSON data for a POST at `/texts/` must be a JSON object containing t
 
 |Key|Value|
 |---|---|
+|`"metadata"`|A JSON object specifying the metadata of the work.|
+|`"file_contents"`|A string containing the contents of a .tess file.|
+
+The JSON object associated with the `"metadata"` field of the request object must have the following keys:
+
+|Key|Value|
+|---|---|
 |`"author"`|A string identifying the text's author.|
 |`"is_prose"`|A boolean value denoting whether the text is a prose work.|
 |`"language"`|A string identifying the composition language of the text.|
-|`"path"`| A string identifying the location of the text's contents.|
 |`"title"`|A string identifying the text's name.|
 |`"year"`|An integer representing the text's publication year; a negative integer corresponds to the BC era.|
 
-The JSON object is forbidden from containing the following keys: `"_id"`, `"id"`, `"object_id"`.
+This metadata JSON object is forbidden from containing the following keys: `"_id"`, `"id"`, `"object_id"`.
 
 ### Response
 
-On success, the response data payload is a JSON object replicating the entry created in Tesserae's database according to the POST request.  Additionally, the `Content-Location` header will specify the URL associated with this newly created database entry.
+On success, the response data payload is a JSON object replicating the entry created in Tesserae's database according to the POST request (in other words, the JSON object associated with the `"metadata"` key in the request object).  Additionally, the `Content-Location` header will specify the URL associated with this newly created database entry.
+
+The work will be ingested in the background. The ingestion status information is displayed in the database entry associated with the URL specified by the `Content-Location` header.
 
 On failure, the data payload contains error information in a JSON object with the following keys:
 


### PR DESCRIPTION
For #32.

POSTing to the /texts/ endpoint continues to be accessible only through an API server running in admin mode.

POSTing to the /texts/ endpoint now requires specification of a "metadata" field (which corresponds to the database entry of a Text) and a "file_contents" field (which should have the contents of a .tess file).

Text entities now have "ingestion_status" and "ingestion_msg" fields that indicate ingestion status for the Text. Successful ingestion will set "ingestion_status" to "Done". Failed ingestion will set "ingestion_status" to "Failed", and failure information can be found in "ingestion_msg".

The endpoint will not check for duplicates, so it is the user's responsibility to ensure that the text they are adding is not already in the database.